### PR TITLE
 Fix negative temps and dewpoints wrapping around to about 6553 degrees C.

### DIFF
--- a/BlueTooth/bluemaestroscan.py
+++ b/BlueTooth/bluemaestroscan.py
@@ -28,6 +28,7 @@ import os
 import sys
 import struct
 import bluetooth._bluetooth as bluez
+from ctypes import c_short
 
 LE_META_EVENT = 0x3e
 LE_PUBLIC_ADDRESS=0x00
@@ -175,7 +176,7 @@ def parse_events(sock, loop_count=100):
 #			  print "\tMAC Address string: ", returnstringpacket(pkt[report_pkt_offset + 3:report_pkt_offset + 9])
 			  tempString = returnstringpacket(pkt[report_pkt_offset + 23: report_pkt_offset + 25])
 #			  print "\tTemp: " , tempString 
-			  temp = float(returnnumberpacket(pkt[report_pkt_offset + 23:report_pkt_offset + 25]))/10
+			  temp = float(c_short(returnnumberpacket(pkt[report_pkt_offset + 23:report_pkt_offset + 25])).value)/10
 #			  print "\tTemp: " , temp
 			  sensor["temp"] = temp
 
@@ -185,8 +186,8 @@ def parse_events(sock, loop_count=100):
 			  sensor["humidity"] = humidity 
 
 
-			  dewpoint = float(returnnumberpacket(pkt[report_pkt_offset + 27:report_pkt_offset + 29]))/10
 #			  print "\tDewpoint: " ,dewpoint 
+			  dewpoint = float(c_short(returnnumberpacket(pkt[report_pkt_offset + 27:report_pkt_offset + 29])).value)/10
 			  sensor["dewpoint"] = dewpoint
 
 			  nameLength = int(returnstringpacket(pkt[report_pkt_offset + 32]))

--- a/BlueTooth/bluemaestroscan.py
+++ b/BlueTooth/bluemaestroscan.py
@@ -186,8 +186,8 @@ def parse_events(sock, loop_count=100):
 			  sensor["humidity"] = humidity 
 
 
-#			  print "\tDewpoint: " ,dewpoint 
 			  dewpoint = float(c_short(returnnumberpacket(pkt[report_pkt_offset + 27:report_pkt_offset + 29])).value)/10
+#			  print "\tDewpoint: " ,dewpoint 
 			  sensor["dewpoint"] = dewpoint
 
 			  nameLength = int(returnstringpacket(pkt[report_pkt_offset + 32]))

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 This is a fork of <https://github.com/psyciknz/OpenHAB-Scripts>.
 
 Most files have been removed and only the ones I'm using remains. They are all in the `BlueTooth` folder along with a more detailed readme.
+
+This fork currently contains a cherry-picked fix destined for upstream (jenswilly/OpenHAB-Scripts) and nothing more.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
-This is a fork of <https://github.com/psyciknz/OpenHAB-Scripts>.
-
-Most files have been removed and only the ones I'm using remains. They are all in the `BlueTooth` folder along with a more detailed readme.
-
 This fork currently contains a cherry-picked fix destined for upstream (jenswilly/OpenHAB-Scripts) and nothing more.


### PR DESCRIPTION
Last night I had quite a big hack at the codebase to get this stuff running. I had a few issues with white-space and indentation. Perhaps some of this was down to my editor, who knows, but I did some other major hacking to get things working for my use case too.

Then, I noticed that the negative dewpoint, around -3.0 degs C (as seen in the Blue Maestro app) was being reported at around 6553 degs C, or thereabouts.  I had a hunch that that something wasn't being correctly treated as a signed 16-bit integer. I applied a "cast" through c_short prior to casting to float and that seemed to do the trick.

As I prepared to push a cherry-picked fix from my mishmash of changes, I wondered if the temperature value suffered from a similar issue. The outside temp when I noticed the negative dewpoint last night was hovering above 0 degs C, so I wasn't sure that the same problem didn't apply to the temp value. 

I put the THD sensor in the freezer and cooled it down to -5 degs C, then monitored it both with the BlueMaemo app and the MQTT feed and confirmed that the temp value also wrapped around to about 65530 degs C. I applied the same code change in my working codebase for the temp value and confirmed that fixed the problem. 

So, this pull request is for a changeset that hasn't been tested in a pristine fork (due to whitespace and indentation changes made in my working fork), but it represents precisely the solution I adopted to the reported problem.

Hope this is useful.